### PR TITLE
Build system and CI tweaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk7
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 script:
   - ./gradlew build jacocoTestReport
 after_success:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,8 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'java'
 apply plugin: 'jacoco'
 
-sourceCompatibility = 1.6
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
 
 repositories {
     jcenter()


### PR DESCRIPTION
Travis:
 - Use jdk7 for backwards compatibility.
 - Cradle cache dirs management.
Cradle:
 - Set source and target compatibility to java 7